### PR TITLE
Improvements

### DIFF
--- a/src/main/scala/refinery/package.scala
+++ b/src/main/scala/refinery/package.scala
@@ -14,7 +14,7 @@ package object refinery {
   private[refinery] def invalid[C, E, A](value: NonEmptyChain[E]): ValidatedC[C, E, A] =
     ValidatedC.Invalid(value.map(Error.of[C, E]))
 
-  implicit class ValidatedOps[C, E, A](value: ValidatedC[C, E, A]) {
+  implicit class RefineryValidatedCOps[C, E, A](value: ValidatedC[C, E, A]) {
     def toEither: Either[ValidatedC.Errors[C, E], A] = value match {
       case ValidatedC.Valid(_, a)     => a.asRight[ValidatedC.Errors[C, E]]
       case ValidatedC.Invalid(errors) => errors.asLeft[A]
@@ -38,25 +38,23 @@ package object refinery {
       value.andThen(_.traverse(fn))
   }
 
-  implicit class ValueOps[A](value: A) {
+  implicit class RefineryIdOps[A](value: A) {
     def validC[C, E]: ValidatedC[C, E, A] = value.pure[ValidatedC[C, E, *]]
+
+    def invalidC[C, B]: ValidatedC[C, A, B] = invalid(NonEmptyChain(value))
   }
 
-  implicit class OptionOps[A](value: Option[A]) {
+  implicit class RefineryOptionOps[A](value: Option[A]) {
     def toValidatedC[C, E](error: => E): ValidatedC[C, E, A] = value match {
       case None        => error.invalidC[C, A]
       case Some(value) => value.validC
     }
   }
 
-  implicit class EitherOps[E, A](value: Either[E, A]) {
+  implicit class RefineryEitherOps[E, A](value: Either[E, A]) {
     def toValidatedC[C]: ValidatedC[C, E, A] = value match {
       case Left(error)  => error.invalidC
       case Right(value) => value.validC
     }
-  }
-
-  implicit class FailureOps[E](value: E) {
-    def invalidC[C, A]: ValidatedC[C, E, A] = invalid(NonEmptyChain(value))
   }
 }

--- a/src/main/scala/refinery/package.scala
+++ b/src/main/scala/refinery/package.scala
@@ -31,6 +31,13 @@ package object refinery {
     }
   }
 
+  implicit class RefineryValidatedCTraverseOps[F[_]: Traverse, C, E, A](
+      value: ValidatedC[C, E, F[A]],
+  ) {
+    def andTraverse[B](fn: A => ValidatedC[C, E, B]): ValidatedC[C, E, F[B]] =
+      value.andThen(_.traverse(fn))
+  }
+
   implicit class ValueOps[A](value: A) {
     def validC[C, E]: ValidatedC[C, E, A] = value.pure[ValidatedC[C, E, *]]
   }


### PR DESCRIPTION
- andTraverse
- Rename implicit classes to avoid clashes with ones defined by users
